### PR TITLE
Update queries for 2.13.7 release

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -1,6 +1,6 @@
 [
   {
-     "query": "org:quarkusio milestone:2.13.6.Final is:pr",
+     "query": "org:quarkusio milestone:2.13.7.Final is:pr",
      "version": "2.13.NEXT"
   }
 ]


### PR DESCRIPTION
- Update the query in queries.yaml to reflect the new milestone version
- Change the query from `org:quarkusio milestone:2.13.6.Final is:pr` to `org:quarkusio milestone:2.13.7.Final is:pr`

[queries.yaml]
- Change the query from `org:quarkusio milestone:2.13.6.Final is:pr` to `org:quarkusio milestone:2.13.7.Final is:pr`
