### PR TITLE
Refactor run.java and add JIRA issue type options

### DIFF
--- a/run.java
+++ b/run.java
@@ -182,7 +182,7 @@ class run implements Callable<Integer> {
     }
 
     private String lookupIssueWithGithubLink(JiraRestClient restClient, String githubLink) {
-        SearchResult searchResults = restClient.getSearchClient().searchJql("project = " + JIRA_PROJECT_CODE + " AND issuetype in (Bug, 'Feature', Task) AND 'Git Pull Request' ~ '" + githubLink + "'").claim();
+        SearchResult searchResults = restClient.getSearchClient().searchJql("project = " + JIRA_PROJECT_CODE + " AND 'Git Pull Request' ~ '" + githubLink + "'").claim();
 
         StringBuilder results = new StringBuilder();
         for (Issue issue : searchResults.getIssues()) {


### PR DESCRIPTION
- Update the default value of the `--config` option to `queries.yaml`
- Modify JIRA issue type options from `Bug`, `Feature Request` to `Bug`, `Feature`

[run.java]
- Change the default value of the `--config` option to `queries.yaml`
- Change the JIRA issue type options from `Bug`, `Feature Request` to `Bug`, `Feature`
- Refactor the lookupIssueWithGithubLink() method to use a StringBuilder
